### PR TITLE
hash/maphash: mark call into runtime hash function as not escaping

### DIFF
--- a/src/hash/maphash/maphash.go
+++ b/src/hash/maphash/maphash.go
@@ -193,6 +193,7 @@ func rthash(b []byte, seed uint64) uint64 {
 }
 
 //go:linkname runtime_memhash runtime.memhash
+//go:noescape
 func runtime_memhash(p unsafe.Pointer, seed, s uintptr) uintptr
 
 // Sum appends the hash's current 64-bit value to b.

--- a/test/escape_hash_maphash.go
+++ b/test/escape_hash_maphash.go
@@ -1,0 +1,19 @@
+// errorcheck -0 -m -l
+
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Test escape analysis for hash/maphash.
+
+package escape
+
+import (
+	"hash/maphash"
+)
+
+func f() {
+	var x maphash.Hash // should be stack allocatable
+	x.WriteString("foo")
+	x.Sum64()
+}


### PR DESCRIPTION
This allows maphash.Hash to be allocated on the stack for typical uses.

Fixes #35636

Change-Id: I8366507d26ea717f47a9fb46d3bd69ba799845ac
Reviewed-on: https://go-review.googlesource.com/c/go/+/207444
Run-TryBot: Keith Randall <khr@golang.org>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Brad Fitzpatrick <bradfitz@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
