### PR TITLE
cmd/objdump: reference tracking bug in TestDisasmCode skip message

### DIFF
--- a/src/cmd/objdump/objdump_test.go
+++ b/src/cmd/objdump/objdump_test.go
@@ -176,10 +176,8 @@ func TestDisasm(t *testing.T) {
 
 func TestDisasmCode(t *testing.T) {
 	switch runtime.GOARCH {
-	case "mips", "mipsle", "mips64", "mips64le":
-		t.Skipf("skipping on %s, issue 12559", runtime.GOARCH)
-	case "s390x":
-		t.Skipf("skipping on %s, issue 15255", runtime.GOARCH)
+	case "mips", "mipsle", "mips64", "mips64le", "s390x":
+		t.Skipf("skipping on %s, issue 19160", runtime.GOARCH)
 	}
 	testDisasm(t, true)
 }


### PR DESCRIPTION
Issue #12559 was closed and split into #19158 for mips{,le} and #19156
for mips64{,le}. Instead of referencing the individual GOARCH-specific
issues in the skip test messages of TestDisasmCode use the tracking bug

Change-Id: I6929d25f4ec5aef4f069b7692c4e29106088ce65
Reviewed-on: https://go-review.googlesource.com/c/go/+/209817
Run-TryBot: Tobias Klauser <tobias.klauser@gmail.com>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
