### PR TITLE
doc: add missing p in install from source page

### DIFF
--- a/doc/install-source.html
+++ b/doc/install-source.html
@@ -247,10 +247,12 @@ that if Go is checked out in <code>$HOME/go</code>, it will conflict with
 the default location of <code>$GOPATH</code>.
 See <a href="#gopath"><code>GOPATH</code></a> below.</p>
 
+<p>
 Reminder: If you opted to also compile the bootstrap binaries from source (in an
 earlier section), you still need to <code>git clone</code> again at this point
 (to checkout the latest <code>&lt;tag&gt;</code>), because you must keep your
 go1.4 repository distinct.
+</p>
 
 <h2 id="head">(Optional) Switch to the master branch</h2>
 


### PR DESCRIPTION
The last paragraph in golang.org/doc/install/source#fetch is missing a
p tag, so it doesn't get formatted with the 'max-width: 50rem' like
all the other text in the page.

Add it.

Change-Id: I1a981dd2afde561b4ab21bd90ad99b3a146111f6
Reviewed-on: https://go-review.googlesource.com/c/go/+/210122
Reviewed-by: Brad Fitzpatrick <bradfitz@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
