### PR TITLE
cmd/go: restore default vet analyzers for targets in GOROOT

### DIFF
--- a/src/cmd/go/internal/vet/vet.go
+++ b/src/cmd/go/internal/vet/vet.go
@@ -51,6 +51,7 @@ func runVet(cmd *base.Command, args []string) {
 
 	work.BuildInit()
 	work.VetFlags = vetFlags
+	work.VetExplicit = true
 	if vetTool != "" {
 		var err error
 		work.VetTool, err = filepath.Abs(vetTool)

--- a/src/cmd/go/internal/work/exec.go
+++ b/src/cmd/go/internal/work/exec.go
@@ -1036,7 +1036,7 @@ func (b *Builder) vet(a *Action) error {
 		// There's too much unsafe.Pointer code
 		// that vet doesn't like in low-level packages
 		// like runtime, sync, and reflect.
-		vetFlags = append(vetFlags, string("-unsafeptr=false"))
+		vetFlags = []string{"-unsafeptr=false"}
 	}
 
 	// Note: We could decide that vet should compute export data for
@@ -1774,6 +1774,11 @@ func (b *Builder) fmtcmd(dir string, format string, args ...interface{}) string 
 	}
 	if b.WorkDir != "" {
 		cmd = strings.ReplaceAll(cmd, b.WorkDir, "$WORK")
+		escaped := strconv.Quote(b.WorkDir)
+		escaped = escaped[1 : len(escaped)-1] // strip quote characters
+		if escaped != b.WorkDir {
+			cmd = strings.ReplaceAll(cmd, escaped, "$WORK")
+		}
 	}
 	return cmd
 }

--- a/src/cmd/go/testdata/script/vet_flags.txt
+++ b/src/cmd/go/testdata/script/vet_flags.txt
@@ -1,8 +1,34 @@
-env GO111MODULE=off
+env GO111MODULE=on
 
-# Issue 35837. Verify that "go vet -<analyzer> <std package>" works if 'pwd' is not $GOROOT/src
-# we utilize the package runtime/testdata/testprog as the issue is specific to vetting standard package
-
-go vet -n -unreachable=false runtime/testdata/testprog
+# Regression test for issue 35837: "go vet -<analyzer> <std package>"
+# did not apply the requested analyzer.
+go vet -n -unreachable=false encoding/binary
 stderr '-unreachable=false'
-stderr '-unsafeptr=false'
+! stderr '-unsafeptr=false'
+
+[short] stop
+env GOCACHE=$WORK/gocache
+env GOTMPDIR=$WORK/tmp
+go env GOTMPDIR
+stdout '/tmp'
+
+# "go test" on a user package should by default enable an explicit whitelist of analyzers.
+go test -x -run=none .
+stderr '[/\\]vet'$GOEXE'["]? .* -errorsas .* ["]?\$WORK[/\\][^ ]*[/\\]vet\.cfg'
+
+# "go test" on a standard package should by default disable an explicit blacklist.
+go test -x -run=none encoding/binary
+stderr '[/\\]vet'$GOEXE'["]? -unsafeptr=false ["]?\$WORK[/\\][^ ]*[/\\]vet\.cfg'
+
+# Both should allow users to override via the -vet flag.
+go test -x -vet=unreachable -run=none .
+stderr '[/\\]vet'$GOEXE'["]? -unreachable ["]?\$WORK[/\\][^ ]*[/\\]vet\.cfg'
+go test -x -vet=unreachable -run=none encoding/binary
+stderr '[/\\]vet'$GOEXE'["]? -unreachable ["]?\$WORK[/\\][^ ]*[/\\]vet\.cfg'
+
+-- go.mod --
+module example.com/x
+-- x.go --
+package x
+-- x_test.go --
+package x


### PR DESCRIPTION
This fixes a regression introduced in CL 209498,
found while investigating #32471.

Also fix $WORK replacement in cmd/go/internal/work.(*Builder).Showcmd
when b.WorkDir includes a backslash and appears in a quoted string.
That fix is needed in order to write a precise test that passes under Windows,
since Windows directories nearly always include backslashes.

Updates #35837

Change-Id: I5fddc5435d5d283a3e598989209d873b59b0a39c
Reviewed-on: https://go-review.googlesource.com/c/go/+/210937
Run-TryBot: Bryan C. Mills <bcmills@google.com>
Reviewed-by: Jay Conrod <jayconrod@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
