### PR TITLE
doc: remove expiration from PGP key in security.html

### DIFF
--- a/doc/security.html
+++ b/doc/security.html
@@ -20,7 +20,6 @@ This mail is delivered to a small security team.
 Your email will be acknowledged within 24 hours, and you'll receive a more
 detailed response to your email within 72 hours indicating the next steps in
 handling your report.
-For critical problems, you can encrypt your report using our PGP key (listed below).
 </p>
 
 <p>
@@ -42,8 +41,8 @@ security team directly:
 </p>
 
 <ul>
-<li>Primary security coordinator: <a href="mailto:filippo@golang.org">Filippo Valsorda</a> (<a href="https://keybase.io/filippo/pgp_keys.asc">public key</a>).</li>
-<li>Secondary coordinator: <a href="mailto:agl@golang.org">Adam Langley</a> (<a href="https://www.imperialviolet.org/key.asc">public key</a>).</li>
+<li>Primary security coordinator: <a href="mailto:filippo@golang.org">Filippo Valsorda</a>.</li>
+<li>Secondary coordinator: <a href="mailto:agl@golang.org">Adam Langley</a>.</li>
 <li>If you receive no response, mail <a href="mailto:golang-dev@googlegroups.com">golang-dev@googlegroups.com</a> or use the <a href="https://groups.google.com/forum/#!forum/golang-dev">golang-dev web interface</a>.</li>
 </ul>
 
@@ -130,7 +129,6 @@ use PGP for critical security reports.
 
 <pre>
 -----BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: GPGTools - https://gpgtools.org
 
 mQINBFXI1h0BEADZdm05GDFWvjmQKutUVb0cJKS+VR+6XU3g/YQZGC8tnIL6i7te
 +fPJHfQc2uIw0xeBgZX4Ni/S8yIqsbIjqYeaToX7QFUufJDQwrmlQRDVAvvT5HBT
@@ -143,42 +141,43 @@ X3tk/nYw2H0YDjTkTCgGtyAOj3Cfqrtsa5L0jG5K2p4RY8mtVgQ5EOh7QxuS+rmN
 JiA39SWh7O6uFCwkz/OCXzqeh6/nP10HAb9S9IC34QQxm7Fhd0ZXzEv9IlBTIRzk
 xddSdACPnLE1gJcFHxBd2LTqS/lmAFShCsf8S252kagKJfHRebQJZHCIs6kT9PfE
 0muq6KRKeDXv01afAUvoB4QW/3chUrtgL2HryyO8ugMu7leVGmoZhFkIrQARAQAB
-tCZHbyBTZWN1cml0eSBUZWFtIDxzZWN1cml0eUBnb2xhbmcub3JnPokCPQQTAQoA
-JwUCVcjWHQIbAwUJB4YfgAULCQgHAwUVCgkICwUWAgMBAAIeAQIXgAAKCRA6RtGR
-eVpYOLnDD/9YVTd6DTwdJq6irVfM/ICPlPTXB0JLERqCI1Veptcp56eQoJ0XWGQp
-tkGlgbvmCzFo0B+65Te7YA4R3oyBCXd6JgyWQQPy5p60FHyuuCPVAReclSWyt9f2
-Yj/u4DjghKhELOvPiI96egcU3g9jrEEcPjm7JYkc9M2gVSNOnnJvcD7wpQJNCzon
-51eMZ1ZyfA5UCBTa0SaT9eXg5zwNlYQnB6ZF6TjXezkhLqlTsBuHxoNVf+9vCC0o
-ZKIM2ovptMx9eEguTDKWaQ7tero7Zs/q5fwk/MDzM/LGJ9aXy2RCtqBxv46vDS7G
-fCNq+aPD/wyFd6hxQkvkua6hgZwYT+cJWHYA2Yv0LO3BYOJdjfc+j2hjv+mC9lF0
-UpWhCVJv3hHoFaxnz62GdROzf2wXz6aR9Saj1rYSvqT9jC20VInxqMufXNN2sbpo
-Kyk6MTbAeepphQpfAWQv+ltWgBiEjuFxYdwv/vmw20996JV7O8nqkeCUW84B6su+
-Y3bbdP9o3DBtOT0j9LTB/FucmdNCNHoO+EnNBKJd6FoYTGLWi3Rq9DLx2V9tdJHo
-Bn67dymcl+iyp337HJNY+qS+KCgoqAWlxkzXRiXKb/yluhXdIkqhg4kL8JPAJvfS
-cs7Zn67Mx04ixJnRMYCDmxtD4xPsFMzM7g8m3PQp+nE7WhujM/ImM7kCDQRVyNYd
-ARAAlw9H/1ybQs4K3XKA1joII16rta9KS7ew76+agXo0jeSRwMEQfItOxYvfhmo8
-+ydn5TWsTbifGU8L3+EBTMRRyzWhbaGO0Wizw7BTVJ7n5JW+ndPrcUpp/ilUk6AU
-VxaO/8/R+9+VJZpoeoLHXYloFGNuX58GLIy1jSBvLsLl/Ki5IOrHvD1GK6TftOl5
-j8IPC1LSBrwGJO803x7wUdQP/tsKN/QPR8pnBntrEgrQFSI+Q3qrCvVMmXnBlYum
-jfOBt8pKMgB9/ix+HWN8piQNQiJxD+XjEM6XwUmQqIR7y5GINKWgundCmtYIzVgY
-9p2Br6UPrTJi12LfKv5s2R6NnxFHv/ad29CpPTeLJRsSqFfqBL969BCpj/isXmQE
-m4FtziZidARXo12KiGAnPF9otirNHp4+8hwNB3scf7cI53y8nZivO9cwI7BoClY6
-ZIabjDcJxjK+24emoz3mJ5SHpZpQLSb9o8GbLLfXOq+4uzEX2A30fhrtsQb/x0GM
-4v3EU1aP2mjuksyYbgldtY64tD35wqAA9mVl5Ux+g1HoUBvLw0h+lzwh370NJw//
-ITvBQVUtDMB96rfIP4fL5pYl5pmRz+vsuJ0iXzm05qBgKfSqO7To9SWxQPdX89R4
-u0/XVAlw0Ak9Zceq3W96vseEUTR3aoZCMIPiwfcDaq60rWUAEQEAAYkCJQQYAQoA
-DwUCVcjWHQIbDAUJB4YfgAAKCRA6RtGReVpYOEg/EADZcIYw4q1jAbDkDy3LQG07
-AR8QmLp/RDp72RKbCSIYyvyXEnmrhUg98lUG676qTH+Y7dlEX107dLhFuKEYyV8D
-ZalrFQO/3WpLWdIAmWrj/wq14qii1rgmy96Nh3EqG3CS50HEMGkW1llRx2rgBvGl
-pgoTcwOfT+h8s0HlZdIS/cv2wXqwPgMWr1PIk3as1fu1OH8n/BjeGQQnNJEaoBV7
-El2C/hz3oqf2uYQ1QvpU23F1NrstekxukO8o2Y/fqsgMJqAiNJApUCl/dNhK+W57
-iicjvPirUQk8MUVEHXKhWIzYxon6aEUTx+xyNMBpRJIZlJ61FxtnZhoPiAFtXVPb
-+95BRJA9npidlVFjqz9QDK/4NSnJ3KaERR9tTDcvq4zqT22Z1Ai5gWQKqogTz5Mk
-F+nZwVizW0yi33id9qDpAuApp8o6AiyH5Ql1Bo23bvqS2lMrXPIS/QmPPsA76CBs
-lYjQwwz8abUD1pPdzyYtMKZUMwhicSFOHFDM4oQN16k2KJuntuih8BKVDCzIOq+E
-KHyeh1BqWplUtFh1ckxZlXW9p9F7TsWjtfcKaY8hkX0Cr4uVjwAFIjLcAxk67ROe
-huEb3Gt+lwJz6aNnZUU87ukMAxRVR2LL0btdxgc6z8spl66GXro/LUkXmAdyOEMV
-UDrmjf9pr7o00hC7lCHFzw==
-=WE0r
+tCZHbyBTZWN1cml0eSBUZWFtIDxzZWN1cml0eUBnb2xhbmcub3JnPokCTgQTAQoA
+OAIbAwULCQgHAwUVCgkICwUWAgMBAAIeAQIXgBYhBGROHzjvGgTlE7xbTTpG0ZF5
+Wlg4BQJd8rfQAAoJEDpG0ZF5Wlg4198P/2YDcEwEqWBWjriLFXdTGOcVxQ7AC/mX
+Fe576zwgmrbqO00IaHOOqZZYXKd078FZyg2qQKILvfSAQB7EtLwfPEgv3Wca/Jb/
+ma2hNz+AveiWDVuF4yPx8qvFer/6Yzv9+anfpUP//qfo/7L3VSYKwNAcqqNGvBMh
+fLb7oWDSkdRmcu57c4WYv8i5BtxMRXs581r836bG3U0z0WQG8j64RpYp6sipqJnv
+09l3R5SXd7kkS26ntLU4fgTNJ6Eim7YoXsqLtVe4VZHGYz3D0yHnvCBpbJa2WpP2
+QT6TtFizvKtQlC0k1uo88VV8DyRdp2V6BO9cSNecvXZh81H0SjtD9MwdMnpX3shT
+LKu3L6wlJtb/EJVZg6+usJo0VunUdNTiBmy4FJrko7YYOSVHKKBA6dooufGNUSjw
+9Tieqh4jnzpg6+aIrNugZIrABH2G0GD/SvUSfjli0i+D1mqQSsMcLzE1BBcichpS
+htjv6fU8nI5XXmloUn1P2WBwziemsb7YcfBLNVeCxlAmoJn1hnOPjNzmKfVZk95E
+VJNvVB76JCh+S/0bAba5+nBZ1HRn/FAbs9vfUpp1sOFf25jX9bDAZvkqwgyPpNv/
+jONK0zNXRD5AfKdCA1nkMI70NNS5oBxPowp95eKyuw4hCINvfuPq5sLJa3cIMj3M
+MVO91QDs9eXxuQINBFXI1h0BEACXD0f/XJtCzgrdcoDWOggjXqu1r0pLt7Dvr5qB
+ejSN5JHAwRB8i07Fi9+Gajz7J2flNaxNuJ8ZTwvf4QFMxFHLNaFtoY7RaLPDsFNU
+nufklb6d0+txSmn+KVSToBRXFo7/z9H735Ulmmh6gsddiWgUY25fnwYsjLWNIG8u
+wuX8qLkg6se8PUYrpN+06XmPwg8LUtIGvAYk7zTfHvBR1A/+2wo39A9HymcGe2sS
+CtAVIj5DeqsK9UyZecGVi6aN84G3ykoyAH3+LH4dY3ymJA1CInEP5eMQzpfBSZCo
+hHvLkYg0paC6d0Ka1gjNWBj2nYGvpQ+tMmLXYt8q/mzZHo2fEUe/9p3b0Kk9N4sl
+GxKoV+oEv3r0EKmP+KxeZASbgW3OJmJ0BFejXYqIYCc8X2i2Ks0enj7yHA0Hexx/
+twjnfLydmK871zAjsGgKVjpkhpuMNwnGMr7bh6ajPeYnlIelmlAtJv2jwZsst9c6
+r7i7MRfYDfR+Gu2xBv/HQYzi/cRTVo/aaO6SzJhuCV21jri0PfnCoAD2ZWXlTH6D
+UehQG8vDSH6XPCHfvQ0nD/8hO8FBVS0MwH3qt8g/h8vmliXmmZHP6+y4nSJfObTm
+oGAp9Ko7tOj1JbFA91fz1Hi7T9dUCXDQCT1lx6rdb3q+x4RRNHdqhkIwg+LB9wNq
+rrStZQARAQABiQI2BBgBCgAgAhsMFiEEZE4fOO8aBOUTvFtNOkbRkXlaWDgFAl3y
+uFYACgkQOkbRkXlaWDiMgw//YvO2nZxWNSnQxqCEi8RXHV/3qsDDe8LloviFFV/M
+GSiGZBOhLJ0bFm9aKKPoye5mrZXBKvEVPu0h1zn43+lZruhARPiTu2AecQ7fstET
+PyXMZJ4mfLSFIaAumuH9dQEQJA9RRaFK8uzPRgAxVKyuNYS89psz/RvSeRM3B7Li
+m9waLs42+5xtltR5F6HKPhrgS/rrFHKMrNiDNMMG2FYu1TjonA9QnzAxDPixH3A1
+VNEj6tVqVK8wCMpci3YaXZJntX0H3oO6qloL8qIpSMVrIiD4IDBDK13Jn3OJ7veq
+iDn1mbGFYtfu8R+QV2xeDSJ6nEKfV3Mc3PFDbJMdzkOCdvExC8qsuUOqO4J6dRt7
+9NVptL0xZqlBjpF9fq9XCt7ZcQLDqbUF/rUs58yKSqEGrruXTx4cTLtwkTLcqJOw
+/CSgFtE8cvY51uupuEFzfmt8JLNTxsm2X2NlsZYxFJhamVrGFroa55nqgKe3tF7e
+AQBU641SZRYloqGgPK+4PB79vV4RyEDETOpD3PvpN2IafVWDacI4LXW0a4EKnPUj
+7JwRBmZxESda3OixSONv/VcuEOyGAZUppbLM4XYTtslRIqdQJFr7Vkza/VIoUqaY
+MkFIioHf2QndVwDXt3d0b0aAGaLeMRD1MFGtLNigEDD45nPeEpuGzXkUATpVWGiV
+bIs=
+=Nx85
 -----END PGP PUBLIC KEY BLOCK-----
 </pre>


### PR DESCRIPTION
The key had expired earlier this year. Simply resigned it with no
expiration, so it maintains the same fingerprint.

Removed the encouragement to use PGP above the fold. We trust the
security of our mail system, so it's really only there for people that
want it.

Also removed the individual keys, as they were never used, and both Adam
and I have access to the security@golang.org key anyway.

Change-Id: Icc5ad6dfb4f0b52128a59a080b7f270b20d3c520
Reviewed-on: https://go-review.googlesource.com/c/go/+/211177
Reviewed-by: Katie Hockman <katie@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
