### PR TITLE
internal/poll: use fcntl64 on 32-bit GNU/Linux systems

### DIFF
--- a/src/go/build/deps_test.go
+++ b/src/go/build/deps_test.go
@@ -168,7 +168,7 @@ var pkgDeps = map[string][]string{
 	},
 
 	"internal/cfg":     {"L0"},
-	"internal/poll":    {"L0", "internal/oserror", "internal/race", "syscall", "time", "unicode/utf16", "unicode/utf8", "internal/syscall/windows"},
+	"internal/poll":    {"L0", "internal/oserror", "internal/race", "syscall", "time", "unicode/utf16", "unicode/utf8", "internal/syscall/windows", "internal/syscall/unix"},
 	"internal/testlog": {"L0"},
 	"os":               {"L1", "os", "syscall", "time", "internal/oserror", "internal/poll", "internal/syscall/windows", "internal/syscall/unix", "internal/testlog"},
 	"path/filepath":    {"L2", "os", "syscall", "internal/syscall/windows"},

--- a/src/internal/poll/splice_linux.go
+++ b/src/internal/poll/splice_linux.go
@@ -5,6 +5,7 @@
 package poll
 
 import (
+	"internal/syscall/unix"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
@@ -169,7 +170,7 @@ func newTempPipe() (prfd, pwfd int, sc string, err error) {
 		defer atomic.StorePointer(&disableSplice, unsafe.Pointer(p))
 
 		// F_GETPIPE_SZ was added in 2.6.35, which does not have the -EAGAIN bug.
-		if _, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fds[0]), syscall.F_GETPIPE_SZ, 0); errno != 0 {
+		if _, _, errno := syscall.Syscall(unix.FcntlSyscall, uintptr(fds[0]), syscall.F_GETPIPE_SZ, 0); errno != 0 {
 			*p = true
 			destroyTempPipe(fds[0], fds[1])
 			return -1, -1, "fcntl", errno


### PR DESCRIPTION
Use FcntlSyscall from internal/syscall/unix to get fcntl64 on 32-bit
Linux systems.

Updates #36211

Change-Id: If48a6e09606ca9f7f6e22f3e8dc9a25fb3ccaf65
Reviewed-on: https://go-review.googlesource.com/c/go/+/212537
Run-TryBot: Tobias Klauser <tobias.klauser@gmail.com>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
