### PR TITLE
internal/poll: use correct fcntl implementations

### DIFF
--- a/src/internal/poll/fcntl_js.go
+++ b/src/internal/poll/fcntl_js.go
@@ -1,0 +1,14 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build js,wasm
+
+package poll
+
+import "syscall"
+
+// fcntl not supported on js/wasm
+func fcntl(fd int, cmd int, arg int) (int, error) {
+	return 0, syscall.ENOSYS
+}

--- a/src/internal/poll/fcntl_libc.go
+++ b/src/internal/poll/fcntl_libc.go
@@ -1,0 +1,13 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build aix darwin solaris
+
+package poll
+
+import _ "unsafe" // for go:linkname
+
+// Implemented in the syscall package.
+//go:linkname fcntl syscall.fcntl
+func fcntl(fd int, cmd int, arg int) (int, error)

--- a/src/internal/poll/fcntl_syscall.go
+++ b/src/internal/poll/fcntl_syscall.go
@@ -1,0 +1,20 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build dragonfly freebsd linux netbsd openbsd
+
+package poll
+
+import (
+	"internal/syscall/unix"
+	"syscall"
+)
+
+func fcntl(fd int, cmd int, arg int) (int, error) {
+	r, _, e := syscall.Syscall(unix.FcntlSyscall, uintptr(fd), uintptr(cmd), uintptr(arg))
+	if e != 0 {
+		return int(r), syscall.Errno(e)
+	}
+	return int(r), nil
+}

--- a/src/internal/poll/fd_fsync_darwin.go
+++ b/src/internal/poll/fd_fsync_darwin.go
@@ -4,10 +4,7 @@
 
 package poll
 
-import (
-	"syscall"
-	_ "unsafe" // for go:linkname
-)
+import "syscall"
 
 // Fsync invokes SYS_FCNTL with SYS_FULLFSYNC because
 // on OS X, SYS_FSYNC doesn't fully flush contents to disk.
@@ -21,7 +18,3 @@ func (fd *FD) Fsync() error {
 	_, e1 := fcntl(fd.Sysfd, syscall.F_FULLFSYNC, 0)
 	return e1
 }
-
-// Implemented in syscall/syscall_darwin.go.
-//go:linkname fcntl syscall.fcntl
-func fcntl(fd int, cmd int, arg int) (int, error)

--- a/src/internal/poll/fd_fsync_posix.go
+++ b/src/internal/poll/fd_fsync_posix.go
@@ -16,11 +16,3 @@ func (fd *FD) Fsync() error {
 	defer fd.decref()
 	return syscall.Fsync(fd.Sysfd)
 }
-
-func fcntl(fd int, cmd int, arg int) (int, error) {
-	r, _, e := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(cmd), uintptr(arg))
-	if e != 0 {
-		return int(r), syscall.Errno(e)
-	}
-	return int(r), nil
-}

--- a/src/internal/poll/fd_unix.go
+++ b/src/internal/poll/fd_unix.go
@@ -451,7 +451,7 @@ var tryDupCloexec = int32(1)
 
 // DupCloseOnExec dups fd and marks it close-on-exec.
 func DupCloseOnExec(fd int) (int, string, error) {
-	if atomic.LoadInt32(&tryDupCloexec) == 1 {
+	if syscall.F_DUPFD_CLOEXEC != 0 && atomic.LoadInt32(&tryDupCloexec) == 1 {
 		r0, e1 := fcntl(fd, syscall.F_DUPFD_CLOEXEC, 0)
 		if e1 == nil {
 			return r0, "", nil

--- a/src/syscall/syscall_aix.go
+++ b/src/syscall/syscall_aix.go
@@ -23,12 +23,12 @@ func syscall6(trap, nargs, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err 
 const (
 	_ = iota
 	TIOCSCTTY
-	F_DUPFD_CLOEXEC
 	SYS_EXECVE
 	SYS_FCNTL
 )
 
 const (
+	F_DUPFD_CLOEXEC = 0
 	// AF_LOCAL doesn't exist on AIX
 	AF_LOCAL = AF_UNIX
 )


### PR DESCRIPTION
Use the libc fcntl (via syscall.fcntl) on aix and solaris like it is
already done for darwin.

For the syscall-based fcntl implementation use FcntlSyscall from
internal/syscall/unix in order to get fcntl64 on 32-bit Linux
systems.

On aix, fcntl with F_DUPFD_CLOEXEC is not supported. Thus, defined
F_DUPFD_CLOEXEC = 0 in the syscall package and check its value before
calling fcntl(fd, syscall.F_DUPFD_CLOEXEC, 0).

On js/wasm, fcntl is not supported thus let its implementation return
ENOSYS directly.

Updates #36211

Change-Id: I96a2ea79e5c4eed2fefd94d0aefd72c940825682
Reviewed-on: https://go-review.googlesource.com/c/go/+/212278
Run-TryBot: Tobias Klauser <tobias.klauser@gmail.com>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
