### PR TITLE
all: fix typo in RuneSelf, runeSelf comments

### DIFF
--- a/src/runtime/utf8.go
+++ b/src/runtime/utf8.go
@@ -7,7 +7,7 @@ package runtime
 // Numbers fundamental to the encoding.
 const (
 	runeError = '\uFFFD'     // the "error" Rune or "Unicode replacement character"
-	runeSelf  = 0x80         // characters below Runeself are represented as themselves in a single byte.
+	runeSelf  = 0x80         // characters below runeSelf are represented as themselves in a single byte.
 	maxRune   = '\U0010FFFF' // Maximum valid Unicode code point.
 )
 

--- a/src/unicode/utf8/utf8.go
+++ b/src/unicode/utf8/utf8.go
@@ -14,7 +14,7 @@ package utf8
 // Numbers fundamental to the encoding.
 const (
 	RuneError = '\uFFFD'     // the "error" Rune or "Unicode replacement character"
-	RuneSelf  = 0x80         // characters below Runeself are represented as themselves in a single byte.
+	RuneSelf  = 0x80         // characters below RuneSelf are represented as themselves in a single byte.
 	MaxRune   = '\U0010FFFF' // Maximum valid Unicode code point.
 	UTFMax    = 4            // maximum number of bytes of a UTF-8 encoded Unicode character.
 )


### PR DESCRIPTION
Fixes #36396

Change-Id: I52190f450fa9ac52fbf4ecdc814e954dc29029cd
Reviewed-on: https://go-review.googlesource.com/c/go/+/213377
Reviewed-by: Daniel Martí <mvdan@mvdan.cc>
Run-TryBot: Daniel Martí <mvdan@mvdan.cc>
TryBot-Result: Gobot Gobot <gobot@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
