### PR TITLE
doc/go1.14: mention changes to debug/dwarf 

### DIFF
--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -512,6 +512,37 @@ TODO
 
 </dl><!-- crypto/tls -->
 
+<dl id="debug/dwarf"><dt><a href="/pkg/debug/dwarf/">debug/dwarf</a></dt>
+  <dd>
+    <p><!-- CL 175138 -->
+      The <code>debug/dwarf</code> package now supports reading DWARF
+      version 5.
+    </p>
+    <p>
+      The new
+      method <a href="/pkg/debug/dwarf/#Data.AddSection"><code>(*Data).AddSection</code></a>
+      supports adding arbitrary new DWARF sections from the input file
+      to the DWARF <code>Data</code>.
+    </p>
+
+    <p><!-- CL 192698 -->
+      The new
+      method <a href="/pkg/debug/dwarf/#Reader.ByteOrder"><code>(*Reader).ByteOrder</code></a>
+      returns the byte order of the current compilation unit.
+      This may be used to interpret attributes that are encoded in the
+      native ordering, such as location descriptions.
+    </p>
+
+    <p><!-- CL 192699 -->
+      The new
+      method <a href="/pkg/debug/dwarf/#LineReader.Files"><code>(*LineReader).Files</code></a>
+      returns the file name table from a line reader.
+      This may be used to interpret the value of DWARF attributes such
+      as <code>AttrDeclFile</code>.
+    </p>
+  </dd>
+</dl><!-- debug/dwarf -->
+
 <dl id="encoding/asn1"><dt><a href="/pkg/encoding/asn1/">encoding/asn1</a></dt>
   <dd>
     <p><!-- CL 126624 -->


### PR DESCRIPTION
Updates #36878

Change-Id: Icfbf9074c731d64198b4760e1902bbd09fcc1349
Reviewed-on: https://go-review.googlesource.com/c/go/+/217067
Reviewed-by: Austin Clements <austin@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
