### PR TITLE
doc/go1.14: rearrange in alphabetical order

### DIFF
--- a/doc/go1.14.html
+++ b/doc/go1.14.html
@@ -419,20 +419,6 @@ appropriately.)
   in mind.
 </p>
 
-<dl id="hash/maphash"><dt><a href="/pkg/hash/maphash/">hash/maphash</a></dt>
-  <dd>
-    <p><!-- CL 186877 -->
-      This new package provides hash functions on byte sequences.
-      These hash functions are intended to be used to implement hash tables or
-      other data structures that need to map arbitrary strings or byte
-      sequences to a uniform distribution of integers.
-    </p>
-    <p>
-      The hash functions are collision-resistant but not cryptographically secure.
-    </p>
-  </dd>
-</dl><!-- hash/maphash -->
-
 <dl id="crypto/tls"><dt><a href="/pkg/crypto/tls/">crypto/tls</a></dt>
   <dd>
     <p><!-- CL 191976 -->
@@ -568,6 +554,40 @@ appropriately.)
   </dd>
 </dl><!-- go/build -->
 
+<dl id="go/doc"><dt><a href="/pkg/go/doc/">go/doc</a></dt>
+  <dd>
+    <p><!-- CL 204830 -->
+      The new
+      function <a href="/pkg/go/doc/#NewFromFiles"><code>NewFromFiles</code></a>
+      computes package documentation from a list
+      of <code>*ast.File</code>'s and associates examples with the
+      appropriate package elements.
+      The new information is available in a new <code>Examples</code>
+      field
+      in the <a href="/pkg/go/doc/#Package"><code>Package</code></a>, <a href="/pkg/go/doc/#Type"><code>Type</code></a>,
+      and <a href="/pkg/go/doc/#Func"><code>Func</code></a> types, and a
+      new <a href="/pkg/go/doc/#Example.Suffix"><code>Suffix</code></a>
+      field in
+      the <a href="/pkg/go/doc/#Example"><code>Example</code></a>
+      type.
+    </p>
+  </dd>
+</dl><!-- go/doc -->
+
+<dl id="hash/maphash"><dt><a href="/pkg/hash/maphash/">hash/maphash</a></dt>
+  <dd>
+    <p><!-- CL 186877 -->
+      This new package provides hash functions on byte sequences.
+      These hash functions are intended to be used to implement hash tables or
+      other data structures that need to map arbitrary strings or byte
+      sequences to a uniform distribution of integers.
+    </p>
+    <p>
+      The hash functions are collision-resistant but not cryptographically secure.
+    </p>
+  </dd>
+</dl><!-- hash/maphash -->
+
 <dl id="io/ioutil"><dt><a href="/pkg/io/ioutil/">io/ioutil</a></dt>
   <dd>
     <p><!-- CL 198488 -->
@@ -590,26 +610,6 @@ appropriately.)
     </p>
   </dd>
 </dl><!-- log -->
-
-<dl id="go/doc"><dt><a href="/pkg/go/doc/">go/doc</a></dt>
-  <dd>
-    <p><!-- CL 204830 -->
-      The new
-      function <a href="/pkg/go/doc/#NewFromFiles"><code>NewFromFiles</code></a>
-      computes package documentation from a list
-      of <code>*ast.File</code>'s and associates examples with the
-      appropriate package elements.
-      The new information is available in a new <code>Examples</code>
-      field
-      in the <a href="/pkg/go/doc/#Package"><code>Package</code></a>, <a href="/pkg/go/doc/#Type"><code>Type</code></a>,
-      and <a href="/pkg/go/doc/#Func"><code>Func</code></a> types, and a
-      new <a href="/pkg/go/doc/#Example.Suffix"><code>Suffix</code></a>
-      field in
-      the <a href="/pkg/go/doc/#Example"><code>Example</code></a>
-      type.
-    </p>
-  </dd>
-</dl><!-- go/doc -->
 
 <dl id="math"><dt><a href="/pkg/math/">math</a></dt>
   <dd>


### PR DESCRIPTION
"Minor changes to the library" are basically arranged in alphabetical
order, but there are some mistakes so we will correct them.

Updates #36878

Change-Id: I8498563b739eff9f1b0a76ead3cf290191e0ce36
Reviewed-on: https://go-review.googlesource.com/c/go/+/218638
Reviewed-by: Dmitri Shuralyov <dmitshur@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
