### PR TITLE
cmd/go/internal/modcmd: remove dead function addModFlag

### DIFF
--- a/src/cmd/go/internal/modcmd/mod.go
+++ b/src/cmd/go/internal/modcmd/mod.go
@@ -7,7 +7,6 @@ package modcmd
 
 import (
 	"cmd/go/internal/base"
-	"cmd/go/internal/cfg"
 )
 
 var CmdMod = &base.Command{
@@ -31,8 +30,4 @@ See 'go help modules' for an overview of module functionality.
 		cmdVerify,
 		cmdWhy,
 	},
-}
-
-func addModFlags(cmd *base.Command) {
-	cmd.Flag.StringVar(&cfg.ModFile, "modfile", "", "")
 }


### PR DESCRIPTION
This function is never called and should have been removed
earlier. work.AddModCommonFlags defines the -modfile flag instead.

Fixes #37189

Change-Id: I73ad2a727013a849cba44bf70de04160f37c97dd
Reviewed-on: https://go-review.googlesource.com/c/go/+/219197
Run-TryBot: Jay Conrod <jayconrod@google.com>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Bryan C. Mills <bcmills@google.com>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
