### PR TITLE
doc: remove extra br tags

### DIFF
--- a/doc/cmd.html
+++ b/doc/cmd.html
@@ -49,7 +49,6 @@ The <code>go</code> program manages Go source code and runs the other
 commands listed here.
 See the command docs for usage
 details.
-<br><br>
 </td>
 </tr>
 


### PR DESCRIPTION
Change-Id: I6db784c67dde058ddaae8d73b295ee02583a1ed4
GitHub-Last-Rev: fea8e66c8ac26809ad1d7f04462cdbde9a41020a
GitHub-Pull-Request: golang/go#37375
Reviewed-on: https://go-review.googlesource.com/c/go/+/220577
Reviewed-by: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
