### PR TITLE
time: add Ticker.Reset

### DIFF
--- a/api/next.txt
+++ b/api/next.txt
@@ -1,1 +1,2 @@
 pkg testing, method (*T) Deadline() (time.Time, bool)
+pkg time, method (*Ticker) Reset(Duration)

--- a/doc/go1.15.html
+++ b/doc/go1.15.html
@@ -80,3 +80,13 @@ TODO
 <p>
 TODO
 </p>
+
+<dl id="time"><dt><a href="/pkg/time/">time</a></dt>
+  <dd>
+    <p><!-- golang.org/issue/33184 -->
+       The new method
+       <a href="/pkg/time#Ticker.Reset"><code>Ticker.Reset</code></a>
+       supports changing the duration of a ticker.
+    </p>
+  </dd>
+</dl><!-- time -->

--- a/src/runtime/time.go
+++ b/src/runtime/time.go
@@ -233,6 +233,12 @@ func resetTimer(t *timer, when int64) {
 	resettimer(t, when)
 }
 
+// modTimer modifies an existing timer.
+//go:linkname modTimer time.modTimer
+func modTimer(t *timer, when, period int64, f func(interface{}, uintptr), arg interface{}, seq uintptr) {
+	modtimer(t, when, period, f, arg, seq)
+}
+
 // Go runtime.
 
 // Ready the goroutine arg.
@@ -402,7 +408,7 @@ func dodeltimer0(pp *p) bool {
 }
 
 // modtimer modifies an existing timer.
-// This is called by the netpoll code.
+// This is called by the netpoll code or time.Ticker.Reset.
 func modtimer(t *timer, when, period int64, f func(interface{}, uintptr), arg interface{}, seq uintptr) {
 	if when < 0 {
 		when = maxWhen

--- a/src/time/sleep.go
+++ b/src/time/sleep.go
@@ -39,6 +39,7 @@ func when(d Duration) int64 {
 func startTimer(*runtimeTimer)
 func stopTimer(*runtimeTimer) bool
 func resetTimer(*runtimeTimer, int64)
+func modTimer(t *runtimeTimer, when, period int64, f func(interface{}, uintptr), arg interface{}, seq uintptr)
 
 // The Timer type represents a single event.
 // When the Timer expires, the current time will be sent on C,

--- a/src/time/tick.go
+++ b/src/time/tick.go
@@ -46,6 +46,15 @@ func (t *Ticker) Stop() {
 	stopTimer(&t.r)
 }
 
+// Reset stops a ticker and resets its period to the specified duration.
+// The next tick will arrive after the new period elapses.
+func (t *Ticker) Reset(d Duration) {
+	if t.r.f == nil {
+		panic("time: Reset called on uninitialized Ticker")
+	}
+	modTimer(&t.r, when(d), int64(d), t.r.f, t.r.arg, t.r.seq)
+}
+
 // Tick is a convenience wrapper for NewTicker providing access to the ticking
 // channel only. While Tick is useful for clients that have no need to shut down
 // the Ticker, be aware that without a way to shut it down the underlying

--- a/src/time/tick_test.go
+++ b/src/time/tick_test.go
@@ -36,13 +36,17 @@ func TestTicker(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		ticker := NewTicker(delta)
 		t0 := Now()
-		for i := 0; i < count; i++ {
+		for i := 0; i < count/2; i++ {
+			<-ticker.C
+		}
+		ticker.Reset(delta * 2)
+		for i := count / 2; i < count; i++ {
 			<-ticker.C
 		}
 		ticker.Stop()
 		t1 := Now()
 		dt := t1.Sub(t0)
-		target := delta * Duration(count)
+		target := 3 * delta * Duration(count/2)
 		slop := target * 2 / 10
 		if dt < target-slop || dt > target+slop {
 			errs = append(errs, fmt.Sprintf("%d %s ticks took %s, expected [%s,%s]", count, delta, dt, target-slop, target+slop))
@@ -114,6 +118,27 @@ func BenchmarkTicker(b *testing.B) {
 		ticker := NewTicker(Nanosecond)
 		for i := 0; i < n; i++ {
 			<-ticker.C
+		}
+		ticker.Stop()
+	})
+}
+
+func BenchmarkTickerReset(b *testing.B) {
+	benchmark(b, func(n int) {
+		ticker := NewTicker(Nanosecond)
+		for i := 0; i < n; i++ {
+			ticker.Reset(Nanosecond * 2)
+		}
+		ticker.Stop()
+	})
+}
+
+func BenchmarkTickerResetNaive(b *testing.B) {
+	benchmark(b, func(n int) {
+		ticker := NewTicker(Nanosecond)
+		for i := 0; i < n; i++ {
+			ticker.Stop()
+			ticker = NewTicker(Nanosecond * 2)
 		}
 		ticker.Stop()
 	})


### PR DESCRIPTION
This CL implements Ticker.Reset method in time package.

Benchmark:
name                 time/op
TickerReset-12       6.41µs ±10%
TickerResetNaive-12  95.7µs ±12%

Fixes #33184

Change-Id: I12c651f81e452541bcbbc748b45f038aae1f8dae
Reviewed-on: https://go-review.googlesource.com/c/go/+/217362
Run-TryBot: Ian Lance Taylor <iant@golang.org>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
