### PR TITLE
doc/articles/race_detector: mention memory leak potential

### DIFF
--- a/doc/articles/race_detector.html
+++ b/doc/articles/race_detector.html
@@ -395,3 +395,14 @@ func (w *Watchdog) Start() {
 The cost of race detection varies by program, but for a typical program, memory
 usage may increase by 5-10x and execution time by 2-20x.
 </p>
+
+<p>
+The race detector currently allocates an extra 8 bytes per <code>defer</code>
+and <code>recover</code> statement. Those extra allocations <a
+href="https://golang.org/issue/26813">are not recovered until the goroutine
+exits</a>. This means that if you have a long-running goroutine that is
+periodically issuing <code>defer</code> and <code>recover</code> calls,
+the program memory usage may grow without bound. These memory allocations
+will not show up in the output of <code>runtime.ReadMemStats</code> or
+<code>runtime/pprof</code>.
+</p>


### PR DESCRIPTION
As far as I can tell, there is no public documentation on this topic,
which cost me several days of debugging.

I am possibly unusual in that I run binaries in production with the
race detector turned on, but I think that others who do the same may
want to be aware of the risk.

Updates #26813.
Updates #37233.

Change-Id: I1f8111bd01d0000596e6057b7cb5ed017d5dc655
Reviewed-on: https://go-review.googlesource.com/c/go/+/220586
Reviewed-by: Dmitri Shuralyov <dmitshur@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
