### PR TITLE
runtime: print instruction bytes when reporting a SIGILL

### DIFF
--- a/test/fixedbugs/issue37513.dir/main.go
+++ b/test/fixedbugs/issue37513.dir/main.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	if len(os.Args) > 1 {
+		// Generate a SIGILL.
+		sigill()
+		return
+	}
+	// Run ourselves with an extra argument. That process should SIGILL.
+	out, _ := exec.Command(os.Args[0], "foo").CombinedOutput()
+	want := "instruction bytes: 0xf 0xb 0xc3"
+	if !bytes.Contains(out, []byte(want)) {
+		fmt.Printf("got:\n%s\nwant:\n%s\n", string(out), want)
+	}
+}
+func sigill()

--- a/test/fixedbugs/issue37513.dir/sigill_amd64.s
+++ b/test/fixedbugs/issue37513.dir/sigill_amd64.s
@@ -1,0 +1,7 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+TEXT ·sigill(SB),0,$0-0
+	UD2	// generates a SIGILL
+	RET

--- a/test/fixedbugs/issue37513.go
+++ b/test/fixedbugs/issue37513.go
@@ -1,0 +1,9 @@
+// buildrundir
+
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,amd64 darwin,amd64 linux,386
+
+package ignored


### PR DESCRIPTION
Print the bytes of the instruction that generated a SIGILL.
This should help us respond to bug reports without having to
go back-and-forth with the reporter to get the instruction involved.
Might also help with SIGILL problems that are difficult to reproduce.

Update #37513

Change-Id: I33059b1dbfc97bce16142a843f32a88a6547e280
Reviewed-on: https://go-review.googlesource.com/c/go/+/221431
Run-TryBot: Keith Randall <khr@golang.org>
TryBot-Result: Gobot Gobot <gobot@golang.org>
Reviewed-by: Ian Lance Taylor <iant@golang.org>

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
